### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "flask run"

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ pip freeze > requirements.txt
 
 * Build command: `python freeze.py`
 * Publish directory: `build`
+
+[![Run on Repl.it](https://repl.it/badge/github/Camps94/personal-website)](https://repl.it/github/Camps94/personal-website)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).